### PR TITLE
Add playwright

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+  PLAYWRIGHT_URL: ${{ secrets.PLAYWRIGHT_URL }}
 
 jobs:
   deploy-api:
@@ -33,3 +34,24 @@ jobs:
       - name: Deploy
         run: sls deploy --stage production
         working-directory: ${{env.working-directory}}
+
+  e2e-test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/web/e2e/list.spec.ts
+++ b/web/e2e/list.spec.ts
@@ -1,0 +1,54 @@
+import { test, type Page } from "@playwright/test";
+
+test.afterEach(async ({ page }) => {
+  const deleteButtons = await page
+    .getByRole("button", { name: "Delete" })
+    .all();
+
+  for (const deleteButton of deleteButtons) {
+    await deleteButton.click();
+  }
+});
+
+const login = async (page: Page): Promise<void> => {
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.getByLabel("Email address").click();
+  await page.getByLabel("Email address").fill("test@email.com");
+  await page.getByLabel("Password").click();
+  await page.getByLabel("Password").fill("testpass");
+  await page.getByRole("button", { name: "Continue" }).click();
+};
+
+test("successfully adds TV show to list", async ({ page }) => {
+  await login(page);
+  await page.getByLabel("Search").click();
+  await page.getByLabel("Search").fill("always sunny");
+  await page
+    .getByRole("option", {
+      name: "It's Always Sunny in Philadelphia poster It's Always Sunny in Philadelphia",
+    })
+    .click();
+});
+
+test("successfully adds movie to list", async ({ page }) => {
+  await login(page);
+  await page.getByRole("checkbox").check();
+  await page.getByLabel("Search").click();
+  await page.getByRole("combobox", { name: "Search" }).fill("the matrix");
+  await page
+    .getByRole("option", { name: "The Matrix poster The Matrix" })
+    .click();
+});
+
+test("successfully marks media as watched", async ({ page }) => {
+  await login(page);
+  await page.getByLabel("Search").click();
+  await page.getByLabel("Search").fill("brooklyn");
+  await page
+    .getByRole("option", {
+      name: "Brooklyn Nine-Nine poster Brooklyn Nine-Nine",
+    })
+    .click();
+  await page.getByRole("button", { name: "Mark as watched" }).click();
+  await page.getByRole("button", { name: "Unmark as watched" }).click();
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "use-debounce": "^9.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.32.2",
         "@sentry/vite-plugin": "^0.5.1",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
@@ -1113,6 +1114,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.32.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
+      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.32.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
@@ -1424,9 +1444,7 @@
       "version": "18.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
       "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -4402,6 +4420,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.32.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
+      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -6064,6 +6094,17 @@
         "fastq": "^1.6.0"
       }
     },
+    "@playwright/test": {
+      "version": "1.32.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
+      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.2"
+      }
+    },
     "@popperjs/core": {
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
@@ -6281,9 +6322,7 @@
       "version": "18.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
       "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -8378,6 +8417,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "playwright-core": {
+      "version": "1.32.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
+      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
       "dev": true
     },
     "postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "use-debounce": "^9.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.32.2",
     "@sentry/vite-plugin": "^0.5.1",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: Boolean(process.env.CI),
+  /* Retry on CI only */
+  retries: Boolean(process.env.CI) ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: Boolean(process.env.CI) ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.PLAYWRIGHT_URL ?? "localhost:5173",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    /* Test against mobile viewports. */
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+    {
+      name: "Mobile Safari",
+      use: { ...devices["iPhone 12"] },
+    },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,6 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "e2e", "playwright.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
This PR adds playwright for end-to-end testing. I've added some basic tests to cover current functionality and extended the CD pipeline to run the E2E tests after a successful deployment.