### PR TITLE
Reduce amount of calls to source configuration for images

### DIFF
--- a/server/src/domain/image/image.test.ts
+++ b/server/src/domain/image/image.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { getImages } from "./image";
+import { buildStubConfiguration } from "../../../test";
 
 describe("image domain", () => {
   it("returns a correctly constructed image map", async () => {
-    const result = await getImages("/foo");
+    const configuration = buildStubConfiguration();
+    const result = await getImages("/foo", configuration);
 
     expect(result).toEqual({
       backdrop: {

--- a/server/src/domain/image/image.ts
+++ b/server/src/domain/image/image.ts
@@ -1,4 +1,4 @@
-import { getConfiguration } from "../configuration";
+import { type TmdbConfigurationResponse } from "../../api";
 
 type ImageMap = Record<string, string>;
 
@@ -50,7 +50,10 @@ const constructImageMap = (
     };
   }, {});
 };
-export const getImages = async (slug: string | null): Promise<Images> => {
+export const getImages = async (
+  slug: string | null,
+  configuration: TmdbConfigurationResponse
+): Promise<Images> => {
   const {
     images: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -66,7 +69,7 @@ export const getImages = async (slug: string | null): Promise<Images> => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       logo_sizes,
     },
-  } = await getConfiguration();
+  } = configuration;
 
   return {
     backdrop: slug

--- a/server/src/domain/list.test.ts
+++ b/server/src/domain/list.test.ts
@@ -2,6 +2,7 @@ import { it, expect, describe } from "vitest";
 import { type Media } from "./media";
 import { getList, type List, updateList } from "./list";
 import { getImages } from "./image";
+import { buildStubConfiguration } from "../../test";
 
 const stubList = async (
   media: List["media"],
@@ -11,6 +12,8 @@ const stubList = async (
 };
 
 describe("list domain", () => {
+  const configuration = buildStubConfiguration();
+
   describe("getList", () => {
     it("returns empty array if user does not have a list", async () => {
       const expectedList: Media[] = [];
@@ -34,7 +37,7 @@ describe("list domain", () => {
         {
           __type: "show",
           title: "Stub Show",
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
           id: 12345,
           isWatched: false,
         },
@@ -61,7 +64,7 @@ describe("list domain", () => {
         {
           __type: "show",
           title: "Stub Show",
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
           id: 12345,
           isWatched: false,
         },

--- a/server/src/domain/media.test.ts
+++ b/server/src/domain/media.test.ts
@@ -1,23 +1,33 @@
 import { type TmdbMovie, type TmdbShow } from "../api";
 import { type Media, mapApiResponseToMedia } from "./media";
-import { buildStubMovie, buildStubShow, dropAllCollections } from "../../test";
+import {
+  buildStubConfiguration,
+  buildStubMovie,
+  buildStubShow,
+  dropAllCollections,
+} from "../../test";
 import { getImages } from "./image";
+import { describe, it, afterAll, expect } from "vitest";
 
 describe("media domain", () => {
   afterAll(async () => {
     await dropAllCollections();
   });
   describe("mapApiResponseToMedia", () => {
+    const configuration = buildStubConfiguration();
+
     it("correctly maps show to media", async () => {
       const input: TmdbShow = buildStubShow();
       const expected: Media = {
         __type: "show",
         id: 12345,
         title: "Stub Show",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
       };
 
-      expect(await mapApiResponseToMedia(input)).toEqual(expected);
+      expect(await mapApiResponseToMedia(input, configuration)).toEqual(
+        expected
+      );
     });
 
     it("correctly maps movie to media", async () => {
@@ -26,10 +36,12 @@ describe("media domain", () => {
         __type: "movie",
         id: 12345,
         title: "Stub Movie",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
       };
 
-      expect(await mapApiResponseToMedia(input)).toEqual(expected);
+      expect(await mapApiResponseToMedia(input, configuration)).toEqual(
+        expected
+      );
     });
   });
 });

--- a/server/src/domain/media.ts
+++ b/server/src/domain/media.ts
@@ -1,4 +1,8 @@
-import { type TmdbMovie, type TmdbShow } from "../api";
+import {
+  type TmdbConfigurationResponse,
+  type TmdbMovie,
+  type TmdbShow,
+} from "../api";
 import { getImages, type Images } from "./image";
 
 // TODO: remove this and replace with common typing
@@ -11,10 +15,11 @@ export interface Media {
 }
 
 export const mapApiResponseToMedia = async (
-  response: TmdbMovie | TmdbShow
+  response: TmdbMovie | TmdbShow,
+  configuration: TmdbConfigurationResponse
 ): Promise<Media> => {
   const isMovie = response.__type === "movie";
-  const images = await getImages(response.poster_path);
+  const images = await getImages(response.poster_path, configuration);
 
   return {
     id: response.id,

--- a/server/src/domain/movie.test.ts
+++ b/server/src/domain/movie.test.ts
@@ -3,15 +3,18 @@ import { type Media } from "./media";
 import { getMovie, searchMovies } from "./movie";
 import * as tmdb from "../../src/api/tmdb";
 import { getImages } from "./image";
+import { buildStubConfiguration } from "../../test";
 
 describe("movie domain", () => {
+  const configuration = buildStubConfiguration();
+
   describe("getMovie", () => {
     it("hits API if not in cache", async () => {
       const apiSpy = vi.spyOn(tmdb, "getMovie");
       const expectedMovie: Media = {
         __type: "movie",
         title: "Stub Movie",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
         id: 12345,
       };
       const result = await getMovie("12345");
@@ -25,7 +28,7 @@ describe("movie domain", () => {
       const expectedMovie: Media = {
         __type: "movie",
         title: "Stub Movie",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
         id: 12345,
       };
       const result = await getMovie("12345");
@@ -42,7 +45,7 @@ describe("movie domain", () => {
         {
           __type: "movie",
           title: "Stub Movie",
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
           id: 12345,
         },
       ];
@@ -59,7 +62,7 @@ describe("movie domain", () => {
           __type: "movie",
           title: "Stub Movie",
           id: 12345,
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
         },
       ];
       const result = await searchMovies("Stub");

--- a/server/src/domain/movie.ts
+++ b/server/src/domain/movie.ts
@@ -5,27 +5,35 @@ import {
 } from "../api/tmdb";
 import { addToCache, retrieveFromCache } from "../db/mongodb/cache";
 import { mapApiResponseToMedia, type Media } from "./media";
+import { getConfiguration } from "./configuration";
 
 export const getMovie = async (id: string): Promise<Media> => {
   const cachedMovie = await retrieveFromCache<TmdbMovie>(id, {
     "data.__type": "movie",
   });
+  const configuration = await getConfiguration();
   if (cachedMovie != null) {
-    return await mapApiResponseToMedia(cachedMovie.data);
+    return await mapApiResponseToMedia(cachedMovie.data, configuration);
   }
 
   const movie = await fetchMovie(id);
   addToCache(id, movie);
 
-  return await mapApiResponseToMedia(movie);
+  return await mapApiResponseToMedia(movie, configuration);
 };
 
 export const searchMovies = async (query: string): Promise<Media[]> => {
   const { results } = await searchMovieRequest(query);
+  const configuration = await getConfiguration();
+
   for (const movie of results) {
     // Don't await caching of data returned from API
     addToCache(movie.id.toString(10), movie);
   }
 
-  return await Promise.all(results.map(mapApiResponseToMedia));
+  return await Promise.all(
+    results.map(
+      async (media) => await mapApiResponseToMedia(media, configuration)
+    )
+  );
 };

--- a/server/src/domain/show.test.ts
+++ b/server/src/domain/show.test.ts
@@ -3,15 +3,18 @@ import { type Media } from "./media";
 import { getShow, searchShows } from "./show";
 import * as tmdb from "../../src/api/tmdb";
 import { getImages } from "./image";
+import { buildStubConfiguration } from "../../test";
 
 describe("show domain", () => {
+  const configuration = buildStubConfiguration();
+
   describe("getShow", () => {
     it("hits API if not in cache", async () => {
       const apiSpy = vi.spyOn(tmdb, "getShow");
       const expectedShow: Media = {
         __type: "show",
         title: "Stub Show",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
         id: 12345,
       };
       const result = await getShow("12345");
@@ -25,7 +28,7 @@ describe("show domain", () => {
       const expectedShow: Media = {
         __type: "show",
         title: "Stub Show",
-        images: await getImages("/posterPath.jpg"),
+        images: await getImages("/posterPath.jpg", configuration),
         id: 12345,
       };
       const result = await getShow("12345");
@@ -42,7 +45,7 @@ describe("show domain", () => {
         {
           __type: "show",
           title: "Stub Show",
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
           id: 12345,
         },
       ];
@@ -58,7 +61,7 @@ describe("show domain", () => {
         {
           __type: "show",
           title: "Stub Show",
-          images: await getImages("/posterPath.jpg"),
+          images: await getImages("/posterPath.jpg", configuration),
           id: 12345,
         },
       ];

--- a/server/src/domain/show.ts
+++ b/server/src/domain/show.ts
@@ -6,20 +6,23 @@ import {
 import { addToCache, retrieveFromCache } from "../db/mongodb/cache";
 import { logger } from "../libs/logger";
 import { mapApiResponseToMedia, type Media } from "./media";
+import { getConfiguration } from "./configuration";
 
 export const getShow = async (id: string): Promise<Media> => {
   logger.profile(`getShow #${id}`);
   const cachedShow = await retrieveFromCache<TmdbShow>(id, {
     "data.__type": "show",
   });
+  const configuration = await getConfiguration();
+
   if (cachedShow != null) {
-    return await mapApiResponseToMedia(cachedShow.data);
+    return await mapApiResponseToMedia(cachedShow.data, configuration);
   }
 
   const movie = await fetchShow(id);
   addToCache(id, movie);
 
-  const mappedMedia = await mapApiResponseToMedia(movie);
+  const mappedMedia = await mapApiResponseToMedia(movie, configuration);
 
   logger.profile(`getShow #${id}`);
 
@@ -29,12 +32,18 @@ export const getShow = async (id: string): Promise<Media> => {
 export const searchShows = async (query: string): Promise<Media[]> => {
   logger.profile(`searchShows: ${query}`);
   const { results } = await searchShowRequest(query);
+  const configuration = await getConfiguration();
+
   for (const show of results) {
     // Don't await caching of data returned from API
     addToCache(show.id.toString(10), show);
   }
 
-  const mappedMedia = await Promise.all(results.map(mapApiResponseToMedia));
+  const mappedMedia = await Promise.all(
+    results.map(
+      async (media) => await mapApiResponseToMedia(media, configuration)
+    )
+  );
   logger.profile(`searchShows: ${query}`);
 
   return mappedMedia;

--- a/server/test/api/tmdb/tmdb.ts
+++ b/server/test/api/tmdb/tmdb.ts
@@ -1,4 +1,8 @@
-import { type TmdbMovie, type TmdbShow } from "../../../src/api/tmdb";
+import {
+  type TmdbConfigurationResponse,
+  type TmdbMovie,
+  type TmdbShow,
+} from "../../../src/api/tmdb";
 
 export const buildStubShow = (
   customData?: Partial<Omit<TmdbShow, "__type">>
@@ -47,7 +51,7 @@ export const buildStubMovie = (
   return { ...defaultData, ...customData };
 };
 
-export const buildStubConfiguration = () => {
+export const buildStubConfiguration = (): TmdbConfigurationResponse => {
   const imageSizes = ["w100", "w300", "w500", "w700", "w1000", "original"];
 
   return {


### PR DESCRIPTION
The Mongo instance was getting smashed with connections and requests to the APIs were taking far too long since we were getting the image configuration data fresh with every function invocation. I have moved the configuration call as high as I can for now, but this will need a bit more thought in the future