### PR TITLE
Add information about TMDB to about page

### DIFF
--- a/web/e2e/about.spec.ts
+++ b/web/e2e/about.spec.ts
@@ -49,4 +49,22 @@ test("about page", async ({ page }) => {
       "At Cinemus, we understand the struggle of constantly being told about new TV shows and movies to watch by friends and family, only to forget them later. We've been there too! That's why we created Cinemus to solve this common problem. Our team is passionate about movies and TV shows, and we know how important it is to keep track of the ones you want to watch. Cinemus was born out of our love for entertainment and our desire to create a web app that makes managing your watchlist simple, fun, and convenient."
     )
   ).toBeVisible();
+
+  // TMDB info
+  await expect(
+    page.getByRole("heading", { name: "Powered by TMDB" })
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Cinemus relies on The Movie Database (TMDB), a comprehensive and community-driven source for TV show and movie information, to provide the data used in our app. TMDB's extensive database, which is constantly updated by a large community of contributors, allows us to deliver a seamless and user-friendly experience to our app users. We are grateful for the valuable contribution of TMDB and its community, which enables us to offer a robust and reliable service to our Cinemus users."
+    )
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Please note that Cinemus is not affiliated with or endorsed by TMDB. We utilize their publicly available data in compliance with their API terms of use. For more information about TMDB, including their data usage policies and terms of service, please visit their official website at https://www.themoviedb.org."
+    )
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "https://www.themoviedb.org" })
+  ).toBeVisible();
 });

--- a/web/src/components/atoms/TmdbInfo/TmdbInfo.tsx
+++ b/web/src/components/atoms/TmdbInfo/TmdbInfo.tsx
@@ -1,0 +1,16 @@
+import { type FC } from "react";
+import Typography from "@mui/material/Typography";
+import { tmdb } from "../../../content";
+export const TmdbInfo: FC = () => (
+  <section>
+    <Typography variant="h2">{tmdb.title}</Typography>
+    <p>{tmdb.body}</p>
+    <p>
+      {tmdb.disclaimer}{" "}
+      <a target={"_blank"} href={tmdb.link} rel="noreferrer">
+        {tmdb.link}
+      </a>
+      .
+    </p>
+  </section>
+);

--- a/web/src/components/atoms/TmdbInfo/index.ts
+++ b/web/src/components/atoms/TmdbInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./TmdbInfo";

--- a/web/src/components/atoms/index.ts
+++ b/web/src/components/atoms/index.ts
@@ -1,3 +1,5 @@
 export * from "./ListItem";
 export * from "./MediaTypeSelector";
 export * from "./Inspiration";
+export * from "./TmdbInfo";
+export * from "./Feature";

--- a/web/src/components/pages/About/About.tsx
+++ b/web/src/components/pages/About/About.tsx
@@ -3,8 +3,7 @@ import Typography from "@mui/material/Typography";
 import styles from "./about.module.css";
 import { Divider } from "@mui/material";
 import { features } from "../../../content";
-import { Feature } from "../../atoms/Feature";
-import { Inspiration } from "../../atoms";
+import { Inspiration, TmdbInfo, Feature } from "../../atoms";
 
 export const About: FC = () => {
   return (
@@ -19,6 +18,8 @@ export const About: FC = () => {
         </Fragment>
       ))}
       <Inspiration />
+      <Divider sx={{ margin: "1rem 0" }} />
+      <TmdbInfo />
     </main>
   );
 };

--- a/web/src/content/index.ts
+++ b/web/src/content/index.ts
@@ -1,2 +1,3 @@
 export * from "./features";
 export * from "./inspiration";
+export * from "./tmdb";

--- a/web/src/content/tmdb.tsx
+++ b/web/src/content/tmdb.tsx
@@ -1,0 +1,7 @@
+export const tmdb = {
+  title: "Powered by TMDB",
+  body: "Cinemus relies on The Movie Database (TMDB), a comprehensive and community-driven source for TV show and movie information, to provide the data used in our app. TMDB's extensive database, which is constantly updated by a large community of contributors, allows us to deliver a seamless and user-friendly experience to our app users. We are grateful for the valuable contribution of TMDB and its community, which enables us to offer a robust and reliable service to our Cinemus users.",
+  disclaimer:
+    "Please note that Cinemus is not affiliated with or endorsed by TMDB. We utilize their publicly available data in compliance with their API terms of use. For more information about TMDB, including their data usage policies and terms of service, please visit their official website at",
+  link: "https://www.themoviedb.org",
+};


### PR DESCRIPTION
This PR adds some text about TMDB to the about page. 

The was done for two reasons:
1. Communicate to the users about where the data is coming from
2. It's part of the TMDB API guidelines