### PR TITLE
Return empty preferences if unable to find

### DIFF
--- a/server/src/domain/userPreferences/userPreferences.ts
+++ b/server/src/domain/userPreferences/userPreferences.ts
@@ -16,10 +16,9 @@ export const getUserPreferences = async (
     userId,
   });
 
-  return (
-    { watchProviderRegion: userPreferences?.watchProviderRegion } ??
-    EMPTY_PREFERENCES
-  );
+  return userPreferences !== null
+    ? { watchProviderRegion: userPreferences.watchProviderRegion }
+    : EMPTY_PREFERENCES;
 };
 
 export const updateUserPreferences = async (


### PR DESCRIPTION
There's a production error with getting user preferences. I think it's due to the collection not existing, so I've added this change as a potential fix