### PR TITLE
Fix user preference calls in serverless

### DIFF
--- a/server/src/db/mongodb/retrieveOne.ts
+++ b/server/src/db/mongodb/retrieveOne.ts
@@ -11,7 +11,6 @@ export const retrieveOne = async <Data extends object>(
   try {
     return await mongoCollection.findOne<Data>(filter);
   } catch (e) {
-    console.error("retrieveOne", (e as Error).message);
     throw Error(
       `Failed to retrieve from collection "${collection}" with filter: ${JSON.stringify(
         filter

--- a/server/src/domain/userPreferences/userPreferences.ts
+++ b/server/src/domain/userPreferences/userPreferences.ts
@@ -1,5 +1,6 @@
 import { retrieveOne } from "../../db/mongodb/retrieveOne";
 import { upsert } from "../../db/mongodb/upsert";
+import { logger } from "../../libs/logger";
 
 interface UserPreferences {
   watchProviderRegion?: string;
@@ -12,9 +13,12 @@ const EMPTY_PREFERENCES = { watchProviderRegion: undefined };
 export const getUserPreferences = async (
   userId: string
 ): Promise<UserPreferences> => {
+  logger.profile("getUserPreferences");
   const userPreferences = await retrieveOne<UserPreferences>(MONGO_COLLECTION, {
     userId,
   });
+
+  logger.profile("getUserPreferences");
 
   return userPreferences !== null
     ? { watchProviderRegion: userPreferences.watchProviderRegion }
@@ -25,9 +29,17 @@ export const updateUserPreferences = async (
   userId: string,
   data: Partial<UserPreferences>
 ): Promise<UserPreferences> => {
+  logger.profile("updateUserPreferences");
   const existingPreferences = await getUserPreferences(userId);
   const updatedPreferences = { ...existingPreferences, ...data };
-  return await upsert<UserPreferences>(MONGO_COLLECTION, updatedPreferences, {
-    userId,
-  });
+  const result = await upsert<UserPreferences>(
+    MONGO_COLLECTION,
+    updatedPreferences,
+    {
+      userId,
+    }
+  );
+  logger.profile("updateUserPreferences");
+
+  return result;
 };

--- a/server/src/domain/watchProviders/watchProviders.ts
+++ b/server/src/domain/watchProviders/watchProviders.ts
@@ -3,6 +3,7 @@ import {
   type TmdbWatchProviderRegionsResponse,
 } from "../../api";
 import { addToCache, retrieveFromCache } from "../../db/mongodb/cache";
+import { logger } from "../../libs/logger";
 
 export interface WatchProviderRegion {
   countryId: string;
@@ -24,6 +25,7 @@ const mapResponseToRegion = (
 export const getWatchProviderRegions = async (): Promise<
   WatchProviderRegion[]
 > => {
+  logger.profile("getWatchProviderRegions");
   const cachedProviders =
     await retrieveFromCache<TmdbWatchProviderRegionsResponse>(CACHE_KEY);
 
@@ -35,6 +37,8 @@ export const getWatchProviderRegions = async (): Promise<
 
   addToCache(CACHE_KEY, response);
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  return mapResponseToRegion(response);
+  const mappedRegions = mapResponseToRegion(response);
+  logger.profile("getWatchProviderRegions");
+
+  return mappedRegions;
 };

--- a/web/src/queries/userPreferences.ts
+++ b/web/src/queries/userPreferences.ts
@@ -13,7 +13,6 @@ export const getUserPreferences = async (
     method: "GET",
     headers: {
       Authorization: `Bearer ${authToken}`,
-      "Content-Type": "application/json",
     },
   });
 

--- a/web/src/queries/watchProviders.ts
+++ b/web/src/queries/watchProviders.ts
@@ -16,7 +16,6 @@ export const getWatchProviderRegions = async (
       method: "GET",
       headers: {
         Authorization: `Bearer ${authToken}`,
-        "Content-Type": "application/json",
       },
     }
   );


### PR DESCRIPTION
This PR fixes the 500 errors coming from the `getUserPreferences` and `getWathProviderRegions`. This was due to the `content-type` header coming from the requests on the frontend. Removing these has fixed the errors.

I have also added some profiling to the domains related to these requests as a bit of tech debt cleanup.