### PR TITLE
Expand posters when hovered (desktop) or tapped(mobile)

### DIFF
--- a/web/e2e/list.spec.ts
+++ b/web/e2e/list.spec.ts
@@ -60,6 +60,9 @@ test("successfully marks media as watched", async ({ page }) => {
       name: "Brooklyn Nine-Nine poster Brooklyn Nine-Nine",
     })
     .click();
-  await page.getByRole("button", { name: "Mark as watched" }).click();
-  await page.getByRole("button", { name: "Unmark as watched" }).click();
+  if (await page.getByLabel("Expand Brooklyn Nine-Nine").isVisible()) {
+    await page.getByLabel("Expand Brooklyn Nine-Nine").click();
+  }
+  await page.getByRole("button", { name: "Mark as seen" }).click();
+  await page.getByRole("button", { name: "Mark as unseen" }).click();
 });

--- a/web/e2e/watchProvider.spec.ts
+++ b/web/e2e/watchProvider.spec.ts
@@ -77,6 +77,13 @@ test("Watch providers", async ({ page }) => {
 
   // Watchlist
   await navigateToList(page);
+  if (
+    await page
+      .getByLabel("Expand It's Always Sunny in Philadelphia")
+      .isVisible()
+  ) {
+    await page.getByLabel("Expand It's Always Sunny in Philadelphia").click();
+  }
   await expect(
     page.getByRole("img", { name: "Disney Plus", exact: true })
   ).toBeVisible();

--- a/web/src/components/atoms/ListItem/ListItem.module.css
+++ b/web/src/components/atoms/ListItem/ListItem.module.css
@@ -1,4 +1,67 @@
+.listItem {
+    display: flex;
+    flex-direction: row;
+    padding: 0.5rem;
+}
+
 .watchProviderLogo {
-    margin: 0 0.5rem;
     border-radius: 4px;
+}
+
+.poster {
+    object-fit: cover;
+    transition: all 0.3s ease;
+}
+
+.poster:hover{
+    width: 100%;
+}
+
+.watchProviders {
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+    margin: 0 0.5rem;
+    gap: 0.5rem;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    gap: 0.5rem;
+    margin: 0.5rem;
+}
+
+.watchProvidersAndActions, .posterAndTitle {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+/* Mobile styles */
+@media screen and (max-width: 900px) {
+    .selected,
+    .selected .listItem,
+    .selected .posterAndTitle,
+    .selected .watchProvidersAndActions {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .selected .poster {
+        width: 100%;
+    }
+
+    .selected .actions {
+        width: 100%;
+    }
+
+    .watchProviders {
+        width: 40px;
+    }
+
+    .selected .watchProviders {
+        width: auto;
+    }
 }

--- a/web/src/components/atoms/ListItem/ListItem.tsx
+++ b/web/src/components/atoms/ListItem/ListItem.tsx
@@ -1,73 +1,96 @@
-import {
-  Box,
-  ListItem as MuiListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Tooltip,
-} from "@mui/material";
+import { Box, ListItem as MuiListItem, ListItemText } from "@mui/material";
 import { type FC } from "react";
 import { type Media } from "../../../types";
-import { Delete, Visibility, VisibilityOff } from "@mui/icons-material";
+import { UnfoldLess, UnfoldMore } from "@mui/icons-material";
 import styles from "./ListItem.module.css";
+import Button from "@mui/material/Button";
 
 interface Props {
   media: Media;
   onRemove: () => void;
   onWatchedChange: (updatedMedia: Media) => void;
+  onSelect: (id: string) => void;
+  isSelected: boolean;
 }
-export const ListItem: FC<Props> = ({ media, onRemove, onWatchedChange }) => {
+export const ListItem: FC<Props> = ({
+  media,
+  onRemove,
+  onWatchedChange,
+  isSelected,
+  onSelect,
+}) => {
   const isWatched = Boolean(media.isWatched);
+
+  const handleWatchedChange = (): void => {
+    onWatchedChange({
+      ...media,
+      isWatched: !Boolean(media.isWatched),
+    });
+  };
+
+  const handleSelect = (): void => {
+    onSelect(isSelected ? "" : media.id);
+  };
   return (
-    <Box flex={"auto"} flexDirection={"row"} padding={"0.5rem"}>
-      <MuiListItem disablePadding>
+    <MuiListItem
+      className={`${styles.listItem} ${isSelected ? styles.selected : ""}`}
+      sx={{ justifyContent: "space-between" }}
+    >
+      <div className={styles.posterAndTitle}>
         <Box paddingRight={"0.5rem"} justifyItems={"center"} display={"flex"}>
           <img
+            className={styles.poster}
             src={media.images.logo.small}
             alt={`${media.title}-image`}
+            onClick={handleSelect}
             width={64}
           />
         </Box>
         <ListItemText>{media.title}</ListItemText>
-        {media.watchProviders?.flatMap(({ flatrate }) =>
-          flatrate?.map(({ logoUrl, name }) => (
-            <img
-              key={name}
-              className={styles.watchProviderLogo}
-              width={32}
-              src={logoUrl}
-              alt={name}
+      </div>
+      <div className={styles.watchProvidersAndActions}>
+        <div className={styles.watchProviders}>
+          {media.watchProviders?.flatMap(({ flatrate }) =>
+            flatrate?.map(({ logoUrl, name }) => (
+              <img
+                key={name}
+                className={styles.watchProviderLogo}
+                width={32}
+                src={logoUrl}
+                alt={name}
+              />
+            ))
+          )}
+        </div>
+        <Box
+          className={styles.actions}
+          sx={{ display: { md: "flex", xs: isSelected ? "flex" : "none" } }}
+        >
+          <Button
+            variant="contained"
+            color={isWatched ? "secondary" : "success"}
+            onClick={handleWatchedChange}
+          >
+            {isWatched ? "Mark as unseen" : "Mark as seen"}
+          </Button>
+          <Button variant="contained" color="error" onClick={onRemove}>
+            Delete
+          </Button>
+        </Box>
+        <Box sx={{ display: { md: "none" } }}>
+          {isSelected ? (
+            <Button onClick={handleSelect}>
+              <UnfoldLess />
+              Collapse
+            </Button>
+          ) : (
+            <UnfoldMore
+              aria-label={`Expand ${media.title}`}
+              onClick={handleSelect}
             />
-          ))
-        )}
-        <Tooltip title={isWatched ? "Unmark as watched" : "Mark as watched"}>
-          <ListItemButton
-            sx={{ flexGrow: 0 }}
-            disableGutters
-            onClick={() => {
-              onWatchedChange({
-                ...media,
-                isWatched: !Boolean(media.isWatched),
-              });
-            }}
-          >
-            <ListItemIcon sx={{ minWidth: "auto" }}>
-              {isWatched ? <VisibilityOff /> : <Visibility />}
-            </ListItemIcon>
-          </ListItemButton>
-        </Tooltip>
-        <Tooltip title={"Delete"}>
-          <ListItemButton
-            sx={{ flexGrow: 0 }}
-            disableGutters
-            onClick={onRemove}
-          >
-            <ListItemIcon sx={{ minWidth: "auto" }}>
-              <Delete />
-            </ListItemIcon>
-          </ListItemButton>
-        </Tooltip>
-      </MuiListItem>
-    </Box>
+          )}
+        </Box>
+      </div>
+    </MuiListItem>
   );
 };

--- a/web/src/components/pages/MediaList/MediaList.tsx
+++ b/web/src/components/pages/MediaList/MediaList.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { type FC, useMemo } from "react";
+import { type FC, useMemo, useState } from "react";
 import { type Media } from "../../../types";
 import { getList, updateList } from "../../../queries/list";
 import { ListItem } from "../../atoms";
@@ -14,6 +14,7 @@ import { useAuth } from "../../../hooks/useAuth";
 
 export const MediaList: FC = () => {
   const { jwt } = useAuth();
+  const [selectedMedia, setSelectedMedia] = useState<string>();
   const { data: userPreferences, isLoading: isUserPreferencesLoading } =
     useQuery(["userPreferences"], async () => await getUserPreferences(jwt), {
       enabled: Boolean(jwt),
@@ -93,6 +94,8 @@ export const MediaList: FC = () => {
                   onWatchedChange={(updatedMedia) => {
                     handleWatchedChange(updatedMedia);
                   }}
+                  onSelect={setSelectedMedia}
+                  isSelected={selectedMedia === media.id}
                 />
                 {index < currentSelections.length - 1 && <Divider />}
               </>


### PR DESCRIPTION
This PR allows posters to expand when tapped (on mobile) or hovered(on desktop) to make them easier to see. Also makes the touch targets for actions (and their descriptions) more usable

## Screenshots:

<img width="374" alt="Screenshot 2023-04-29 at 4 29 40 pm" src="https://user-images.githubusercontent.com/20939486/235287623-1151c4f2-1c46-4366-a8bd-944c4cfc25bd.png">
<img width="1172" alt="Screenshot 2023-04-29 at 4 29 21 pm" src="https://user-images.githubusercontent.com/20939486/235287624-b1e95800-b806-4db8-aecb-15e34cec9271.png">
