### PR TITLE
Sort media searches by popularity

### DIFF
--- a/server/src/api/tmdb/media.ts
+++ b/server/src/api/tmdb/media.ts
@@ -100,7 +100,7 @@ const search = async <MediaType extends Media>(
     logger.profile(`TMDB search ${mediaType} "${query}"`);
     return {
       ...response.data,
-      results: markedMedia,
+      results: markedMedia.sort((a, b) => b.popularity - a.popularity),
     };
   } catch (e) {
     throw Error(

--- a/server/src/domain/movie/movie.test.ts
+++ b/server/src/domain/movie/movie.test.ts
@@ -28,7 +28,7 @@ describe("movie domain", () => {
       await dropAllCollections();
 
       const apiSpy = vi.spyOn(tmdb, "getMovie");
-      const expectedShow: Media = {
+      const expectedMovie: Media = {
         __type: "movie",
         title: "Stub Movie",
         images: getImages("/posterPath.jpg", configuration),
@@ -48,7 +48,7 @@ describe("movie domain", () => {
       const result = await getMovie("12345", "AU");
 
       expect(apiSpy).toHaveBeenCalledOnce();
-      expect(result).toEqual(expectedShow);
+      expect(result).toEqual(expectedMovie);
     });
 
     it("retrieves from cache if it exists", async () => {
@@ -67,7 +67,7 @@ describe("movie domain", () => {
 
     it("retrieves from cache with watch providers if it exists and region is specified", async () => {
       const apiSpy = vi.spyOn(tmdb, "getShow");
-      const expectedShow: Media = {
+      const expectedMovie: Media = {
         __type: "movie",
         title: "Stub Movie",
         images: getImages("/posterPath.jpg", configuration),
@@ -87,7 +87,7 @@ describe("movie domain", () => {
       const result = await getMovie("12345", "AU");
 
       expect(apiSpy).not.toHaveBeenCalled();
-      expect(result).toEqual(expectedShow);
+      expect(result).toEqual(expectedMovie);
     });
   });
 
@@ -97,9 +97,21 @@ describe("movie domain", () => {
       const expectedMovies: Media[] = [
         {
           __type: "movie",
-          title: "Stub Movie",
+          title: "Stub Movie Two",
+          id: 22222,
           images: getImages("/posterPath.jpg", configuration),
-          id: 12345,
+        },
+        {
+          __type: "movie",
+          title: "Stub Movie Three",
+          id: 33333,
+          images: getImages("/posterPath.jpg", configuration),
+        },
+        {
+          __type: "movie",
+          title: "Stub Movie One",
+          id: 11111,
+          images: getImages("/posterPath.jpg", configuration),
         },
       ];
       const result = await searchMovies("Stub");
@@ -113,8 +125,20 @@ describe("movie domain", () => {
       const expectedMovies: Media[] = [
         {
           __type: "movie",
-          title: "Stub Movie",
-          id: 12345,
+          title: "Stub Movie Two",
+          id: 22222,
+          images: getImages("/posterPath.jpg", configuration),
+        },
+        {
+          __type: "movie",
+          title: "Stub Movie Three",
+          id: 33333,
+          images: getImages("/posterPath.jpg", configuration),
+        },
+        {
+          __type: "movie",
+          title: "Stub Movie One",
+          id: 11111,
           images: getImages("/posterPath.jpg", configuration),
         },
       ];

--- a/server/src/domain/show/show.test.ts
+++ b/server/src/domain/show/show.test.ts
@@ -97,9 +97,21 @@ describe("show domain", () => {
       const expectedShows: Media[] = [
         {
           __type: "show",
-          title: "Stub Show",
+          title: "Stub Show Two",
           images: getImages("/posterPath.jpg", configuration),
-          id: 12345,
+          id: 22222,
+        },
+        {
+          __type: "show",
+          title: "Stub Show Three",
+          images: getImages("/posterPath.jpg", configuration),
+          id: 33333,
+        },
+        {
+          __type: "show",
+          title: "Stub Show One",
+          images: getImages("/posterPath.jpg", configuration),
+          id: 11111,
         },
       ];
       const result = await searchShows("Stub");
@@ -113,9 +125,21 @@ describe("show domain", () => {
       const expectedShows: Media[] = [
         {
           __type: "show",
-          title: "Stub Show",
+          title: "Stub Show Two",
           images: getImages("/posterPath.jpg", configuration),
-          id: 12345,
+          id: 22222,
+        },
+        {
+          __type: "show",
+          title: "Stub Show Three",
+          images: getImages("/posterPath.jpg", configuration),
+          id: 33333,
+        },
+        {
+          __type: "show",
+          title: "Stub Show One",
+          images: getImages("/posterPath.jpg", configuration),
+          id: 11111,
         },
       ];
       const result = await searchShows("Stub");

--- a/server/test/mocks/handlers.ts
+++ b/server/test/mocks/handlers.ts
@@ -16,7 +16,26 @@ export const handlers = [
   }),
 
   rest.get(`${url.TMDB_URL}/search/movie`, (req, res, ctx) => {
-    const movie = buildStubMovie();
+    const movies = [
+        buildStubMovie({
+            title: "Stub Movie One",
+            original_title: "Stub Movie One",
+            id: 11111,
+            popularity: 50
+        }),
+        buildStubMovie({
+            title: "Stub Movie Two",
+            id: 22222,
+            original_title: "Stub Movie Two",
+            popularity: 150
+        }),
+        buildStubMovie({
+            title: "Stub Movie Three",
+            id: 33333,
+            original_title: "Stub Movie Three",
+            popularity: 100
+        })
+    ];
 
     return res(
       ctx.status(200),
@@ -24,7 +43,7 @@ export const handlers = [
         page: 1,
         total_pages: 1,
         total_results: 1,
-        results: [movie],
+        results: movies,
       })
     );
   }),
@@ -36,7 +55,26 @@ export const handlers = [
   }),
 
   rest.get(`${url.TMDB_URL}/search/tv`, (req, res, ctx) => {
-    const show = buildStubShow();
+    const shows = [
+        buildStubShow({
+            name: "Stub Show One",
+            original_name: "Stub Show One",
+            id: 11111,
+            popularity: 50
+        }),
+        buildStubShow({
+            name: "Stub Show Two",
+            id: 22222,
+            original_name: "Stub Show Two",
+            popularity: 150
+        }),
+        buildStubShow({
+            name: "Stub Show Three",
+            id: 33333,
+            original_name: "Stub Show Three",
+            popularity: 100
+        })
+    ]
 
     return res(
       ctx.status(200),
@@ -44,7 +82,7 @@ export const handlers = [
         page: 1,
         total_pages: 1,
         total_results: 1,
-        results: [show],
+        results: shows,
       })
     );
   }),


### PR DESCRIPTION
This PR sorts the media search responses from TMDB by their popularity rankings. This should hopefully address some of the Alpha Testing Feedback around search results being in a strange order