### PR TITLE
Restyle media search type selector

### DIFF
--- a/web/src/components/atoms/MediaTypeSelector/MediaTypeSelector.tsx
+++ b/web/src/components/atoms/MediaTypeSelector/MediaTypeSelector.tsx
@@ -1,36 +1,33 @@
-import { type FC } from "react";
-import {
-  FormControl,
-  FormGroup,
-  Stack,
-  Switch,
-  Typography,
-} from "@mui/material";
+import { type FC, type MouseEvent } from "react";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { type MediaType } from "../../../types";
 
 interface Props {
-  defaultValue?: MediaType;
+  value?: MediaType;
   onChange: (mediaType: MediaType) => void;
 }
 
-export const MediaTypeSelector: FC<Props> = ({
-  defaultValue = "show",
-  onChange,
-}) => {
+export const MediaTypeSelector: FC<Props> = ({ value = "show", onChange }) => {
+  const handleChange = (
+    _: MouseEvent<HTMLElement>,
+    value: MediaType | null
+  ): void => {
+    if (value !== null) {
+      onChange(value);
+    }
+  };
+
   return (
-    <FormControl component="fieldset">
-      <FormGroup aria-label="position" row>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Typography>TV Show</Typography>
-          <Switch
-            defaultChecked={defaultValue === "movie"}
-            onChange={(_, checked) => {
-              onChange(checked ? "movie" : "show");
-            }}
-          />
-          <Typography>Movie</Typography>
-        </Stack>
-      </FormGroup>
-    </FormControl>
+    <ToggleButtonGroup
+      id={"mediaType"}
+      value={value}
+      exclusive
+      onChange={handleChange}
+      aria-label={"media selector"}
+      color="primary"
+    >
+      <ToggleButton value="show">TV Show</ToggleButton>
+      <ToggleButton value="movie">Movie</ToggleButton>
+    </ToggleButtonGroup>
   );
 };

--- a/web/src/components/molecules/SearchBox/SearchBox.module.css
+++ b/web/src/components/molecules/SearchBox/SearchBox.module.css
@@ -1,0 +1,3 @@
+.input {
+    flex-grow: 1;
+}

--- a/web/src/components/molecules/SearchBox/SearchBox.tsx
+++ b/web/src/components/molecules/SearchBox/SearchBox.tsx
@@ -9,6 +9,7 @@ import {
   searchShows,
 } from "../../../queries/search";
 import { useAuth } from "../../../hooks/useAuth";
+import styles from "./SearchBox.module.css";
 
 interface Props {
   mediaType: MediaType;
@@ -89,12 +90,13 @@ export const SearchBox: FC<Props> = ({
         selection !== null && handleSelection(selection);
       }}
       noOptionsText="No media found"
+      className={styles.input}
       inputValue={query}
       renderOption={renderOption}
       renderInput={(params) => (
         <TextField
           {...params}
-          label="Search"
+          label={`Search ${mediaType}s`}
           onChange={({ target: { value } }) => {
             setQuery(value);
           }}

--- a/web/src/components/organisms/MediaSearch/MediaSearch.module.css
+++ b/web/src/components/organisms/MediaSearch/MediaSearch.module.css
@@ -1,0 +1,13 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* Desktop styles */
+@media screen and (min-width: 900px) {
+    .container {
+        flex-direction: row;
+        width: 100%;
+    }
+}

--- a/web/src/components/organisms/MediaSearch/MediaSearch.test.tsx
+++ b/web/src/components/organisms/MediaSearch/MediaSearch.test.tsx
@@ -31,10 +31,24 @@ describe("<MediaSearch />", () => {
     );
   };
 
-  it("renders correctly", () => {
-    setup();
+  describe("renders correctly", () => {
+    it("tv show search", async () => {
+      const user = userEvent.setup();
+      setup();
 
-    expect(screen.getByLabelText("Search")).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "TV Show" }));
+
+      expect(screen.getByLabelText("Search shows")).toBeInTheDocument();
+    });
+
+    it("movie search", async () => {
+      const user = userEvent.setup();
+      setup();
+
+      await user.click(screen.getByRole("button", { name: "Movie" }));
+
+      expect(screen.getByLabelText("Search movies")).toBeInTheDocument();
+    });
   });
 
   it("calls setQuery when typed into", async () => {
@@ -42,14 +56,14 @@ describe("<MediaSearch />", () => {
     const querySpy = vi.spyOn(searchQueries, "searchShows");
     setup();
 
-    await user.type(screen.getByLabelText("Search"), "Foo");
+    await user.type(screen.getByLabelText("Search shows"), "Foo");
 
     await sleep(1000);
 
     expect(querySpy).toHaveBeenCalledWith("Foo", "mock-token");
 
-    await user.clear(screen.getByLabelText("Search"));
-    await user.type(screen.getByLabelText("Search"), "Bar");
+    await user.clear(screen.getByLabelText("Search shows"));
+    await user.type(screen.getByLabelText("Search shows"), "Bar");
 
     await sleep(1000);
 

--- a/web/src/components/organisms/MediaSearch/MediaSearch.tsx
+++ b/web/src/components/organisms/MediaSearch/MediaSearch.tsx
@@ -3,6 +3,7 @@ import { type MediaType } from "../../../types";
 import { MediaTypeSelector } from "../../atoms";
 import { SearchBox } from "../../molecules";
 import { type MediaResponse } from "../../../queries/search";
+import styles from "./MediaSearch.module.css";
 
 interface Props {
   onSelect: (selection: MediaResponse) => void;
@@ -17,8 +18,8 @@ export const MediaSearch: FC<Props> = ({ onSelect }) => {
   };
 
   return (
-    <div>
-      <MediaTypeSelector onChange={handleMediaTypeChange} />
+    <div className={styles.container}>
+      <MediaTypeSelector value={mediaType} onChange={handleMediaTypeChange} />
       <SearchBox
         mediaType={mediaType}
         onSelect={onSelect}


### PR DESCRIPTION
Restyles the media search type selector to be a bit more intuitive

## Screenshots

### Before
<img width="609" alt="Screenshot 2023-05-09 at 7 02 46 pm" src="https://user-images.githubusercontent.com/20939486/237048405-d4781482-1718-4e5f-a7bd-135a4ae11ef5.png">
<img width="1243" alt="Screenshot 2023-05-09 at 7 02 39 pm" src="https://user-images.githubusercontent.com/20939486/237048420-a064f720-32e8-44a3-99fd-e16af3146c0a.png">

### After
<img width="585" alt="Screenshot 2023-05-09 at 7 02 33 pm" src="https://user-images.githubusercontent.com/20939486/237048492-30f88bc3-219a-47a4-a87a-1b49cc374714.png">
<img width="1046" alt="Screenshot 2023-05-09 at 7 02 28 pm" src="https://user-images.githubusercontent.com/20939486/237048518-145aaded-b962-4a46-9192-1fc9d99d773e.png">
