### PR TITLE
Bump prisma to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.4",
         "@next-auth/prisma-adapter": "^1.0.5",
-        "@prisma/client": "^4.14.0",
+        "@prisma/client": "^5.0.0",
         "@sentry/nextjs": "^7.54.0",
         "@t3-oss/env-nextjs": "^0.3.1",
         "@tanstack/react-query-devtools": "^4.29.19",
@@ -53,7 +53,7 @@
         "postcss": "^8.4.21",
         "prettier": "^2.8.8",
         "prettier-plugin-tailwindcss": "^0.2.8",
-        "prisma": "^4.14.0",
+        "prisma": "^5.0.0",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.0.4",
         "vite-tsconfig-paths": "^4.2.0"
@@ -1367,15 +1367,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.15.0.tgz",
-      "integrity": "sha512-xnROvyABcGiwqRNdrObHVZkD9EjkJYHOmVdlKy1yGgI+XOzvMzJ4tRg3dz1pUlsyhKxXGCnjIQjWW+2ur+YXuw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
+        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1387,16 +1387,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.15.0.tgz",
-      "integrity": "sha512-FTaOCGs0LL0OW68juZlGxFtYviZa4xdQj/rQEdat2txw0s3Vu/saAPKjNVXfIgUsGXmQ72HPgNr6935/P8FNAA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
+      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
-      "integrity": "sha512-sVOig4tjGxxlYaFcXgE71f/rtFhzyYrfyfNFUsxCIEJyVKU9rdOWIlIwQ2NQ7PntvGnn+x0XuFo4OC1jvPJKzg=="
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "24.0.0",
@@ -7076,20 +7076,19 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prisma": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.15.0.tgz",
-      "integrity": "sha512-iKZZpobPl48gTcSZVawLMQ3lEy6BnXwtoMj7hluoGFYu2kQ6F9LBuBrUyF95zRVnNo8/3KzLXJXJ5TEnLSJFiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
+      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.15.0"
+        "@prisma/engines": "5.0.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       }
     },
     "node_modules/progress": {
@@ -9810,23 +9809,23 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@prisma/client": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.15.0.tgz",
-      "integrity": "sha512-xnROvyABcGiwqRNdrObHVZkD9EjkJYHOmVdlKy1yGgI+XOzvMzJ4tRg3dz1pUlsyhKxXGCnjIQjWW+2ur+YXuw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
       "requires": {
-        "@prisma/engines-version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
+        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
       }
     },
     "@prisma/engines": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.15.0.tgz",
-      "integrity": "sha512-FTaOCGs0LL0OW68juZlGxFtYviZa4xdQj/rQEdat2txw0s3Vu/saAPKjNVXfIgUsGXmQ72HPgNr6935/P8FNAA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
+      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
-      "integrity": "sha512-sVOig4tjGxxlYaFcXgE71f/rtFhzyYrfyfNFUsxCIEJyVKU9rdOWIlIwQ2NQ7PntvGnn+x0XuFo4OC1jvPJKzg=="
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
     },
     "@rollup/plugin-commonjs": {
       "version": "24.0.0",
@@ -13853,12 +13852,12 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "prisma": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.15.0.tgz",
-      "integrity": "sha512-iKZZpobPl48gTcSZVawLMQ3lEy6BnXwtoMj7hluoGFYu2kQ6F9LBuBrUyF95zRVnNo8/3KzLXJXJ5TEnLSJFiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
+      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.15.0"
+        "@prisma/engines": "5.0.0"
       }
     },
     "progress": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.4",
     "@next-auth/prisma-adapter": "^1.0.5",
-    "@prisma/client": "^4.14.0",
+    "@prisma/client": "^5.0.0",
     "@sentry/nextjs": "^7.54.0",
     "@t3-oss/env-nextjs": "^0.3.1",
     "@tanstack/react-query-devtools": "^4.29.19",
@@ -55,7 +55,7 @@
     "postcss": "^8.4.21",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.2.8",
-    "prisma": "^4.14.0",
+    "prisma": "^5.0.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.4",
     "vite-tsconfig-paths": "^4.2.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider        = "prisma-client-js"
-    previewFeatures = ["jsonProtocol"]
+    provider = "prisma-client-js"
 }
 
 datasource db {


### PR DESCRIPTION
Prisma V5 has been released, this allows for the JSON protocol to be used as default, meaning we can remove the preview feature flag

Docs: https://www.prisma.io/docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5