### PR TITLE
Add basic user emulation for admins

### DIFF
--- a/src/components/molecules/UserMenu/UserMenu.tsx
+++ b/src/components/molecules/UserMenu/UserMenu.tsx
@@ -60,6 +60,13 @@ export const UserMenu: FC = () => {
               <Typography textAlign="center">Preferences</Typography>
             </Link>
           </MenuItem>
+          {sessionData.user.role === "ADMIN" && (
+            <MenuItem onClick={handleCloseUserMenu}>
+              <Link href={"/admin"}>
+                <Typography textAlign="center">Admin</Typography>
+              </Link>
+            </MenuItem>
+          )}
           <MenuItem onClick={handleLogout}>
             <Typography textAlign="center">Logout</Typography>
           </MenuItem>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,9 +1,10 @@
-import { GetServerSidePropsContext, type NextPage } from "next";
+import { type GetServerSidePropsContext, type NextPage } from "next";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../server/auth";
 import { api } from "../../utils/api";
 import { Heading } from "../../components/atoms";
 import dayjs from "dayjs";
+import Link from "next/link";
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
@@ -71,6 +72,9 @@ const AdminPage: NextPage = () => {
                       >
                         {latestSession?.expires.toDateString()}
                       </span>
+                      <Link href={`/api/admin/emulateUser?userId=${user.id}`}>
+                        Emulate
+                      </Link>
                     </>
                   )}
                 </li>

--- a/src/server/db/prisma/user.ts
+++ b/src/server/db/prisma/user.ts
@@ -4,10 +4,22 @@ const getUserById = async (userId: string) => {
   return await prisma.user.findUniqueOrThrow({ where: { id: userId } });
 };
 
+const getLatestSessionForUser = async (userId: string) => {
+  return await prisma.session.findFirst({
+    where: { userId },
+    orderBy: { expires: "desc" },
+    select: { sessionToken: true },
+  });
+};
+
 const getAllUsers = async () => {
   return await prisma.user.findMany({ include: { sessions: true } });
 };
 
-const prismaUserFunctions = { getUserById, getAllUsers };
+const prismaUserFunctions = {
+  getUserById,
+  getAllUsers,
+  getLatestSessionForUser,
+};
 
 export default prismaUserFunctions;

--- a/src/server/domain/user/user.ts
+++ b/src/server/domain/user/user.ts
@@ -3,3 +3,7 @@ import user from "~/server/db/prisma/user";
 export const getAllUsers = async () => {
   return await user.getAllUsers();
 };
+
+export const getLatestSessionForUser = async (userId: string) => {
+  return await user.getLatestSessionForUser(userId);
+};


### PR DESCRIPTION
This PR adds user emulation for admins. This allows admin users to enter the selected user's last active session and explore the app as that user (**Currently only works for users with an active session in the database**).

Currently there isn't a simple way for the admin to exit the emulation and return to their original account, that will be added in a follow-up PR