### PR TITLE
Replace tooltips with MUI tooltip

### DIFF
--- a/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/src/components/atoms/Tooltip/Tooltip.tsx
@@ -1,17 +1,12 @@
-import { type FC, type PropsWithChildren } from "react";
+import { type FC, type ReactElement } from "react";
+import MuiTooltip from "@mui/material/Tooltip";
 
-type Props = { content: string };
+type Props = { content: string; children: ReactElement };
 
-export const Tooltip: FC<PropsWithChildren<Props>> = ({
-  children,
-  content,
-}) => {
+export const Tooltip: FC<Props> = ({ children, content }) => {
   return (
-    <div className="group relative">
-      {children}
-      <span className="invisible absolute top-16 z-10 inline-block rounded-sm border border-cinemus-purple bg-white p-2 group-hover:visible group-active:visible">
-        {content}
-      </span>
-    </div>
+    <MuiTooltip disableFocusListener title={content}>
+      <div>{children}</div>
+    </MuiTooltip>
   );
 };

--- a/src/components/molecules/UserStack/UserStack.tsx
+++ b/src/components/molecules/UserStack/UserStack.tsx
@@ -37,7 +37,7 @@ export const UserStack: FC<Props> = ({ users, className }) => {
         <div className="mr-[-12px]" key={JSON.stringify(user)}>
           <Avatar
             user={user}
-            tooltipSuffix={sentenceCase(user.role)}
+            tooltipSuffix={`(${sentenceCase(user.role)})`}
             showTooltip
             className={`border-4 ${
               index === 0 ? borderColours.owner : borderColours.member


### PR DESCRIPTION
This PR fixes an issue where tooltips could overflow the screen. This was especially noticeable on mobile.